### PR TITLE
Fix: Corrige o caminho de assets para o executável PyInstaller

### DIFF
--- a/src/app/main_window.py
+++ b/src/app/main_window.py
@@ -58,7 +58,7 @@ class MainApplication(tk.Frame):
         header_container = tk.Frame(self.main_card_frame, bg=theme["card_bg"], padx=20, pady=15)
         header_container.pack(fill="x", expand=True, pady=(10,0))
         try:
-            logo_image = Image.open(resource_path("logo_guara.png"))
+            logo_image = Image.open(resource_path("assets/logo_guara.png"))
             logo_image.thumbnail((200, 60))
             self.logo_tk = ImageTk.PhotoImage(logo_image)
             tk.Label(header_container, image=self.logo_tk, bg=theme["card_bg"]).pack(pady=(0,10))

--- a/src/app/tray_icon.py
+++ b/src/app/tray_icon.py
@@ -26,7 +26,7 @@ def setup_tray_icon(root, capture_module, recording_module, app_config):
             print(f"Não foi possível abrir a pasta de evidências: {e}")
 
     try:
-        image = Image.open(resource_path("logo_guara.ico"))
+        image = Image.open(resource_path("assets/logo_guara.ico"))
     except FileNotFoundError:
         # Create a placeholder image with the primary theme color
         image = Image.new('RGB', (64, 64), color = theme["primary"])

--- a/src/core/recording.py
+++ b/src/core/recording.py
@@ -175,7 +175,7 @@ class ScreenRecordingModule:
                 # --- Main Recording Loop ---
                 with mss.mss() as sct:
                     try:
-                        cursor_img = Image.open(resource_path("cursor.png")).convert("RGBA").resize((32, 32), Image.Resampling.LANCZOS)
+                        cursor_img = Image.open(resource_path("assets/cursor.png")).convert("RGBA").resize((32, 32), Image.Resampling.LANCZOS)
                     except FileNotFoundError:
                         cursor_img = None
                     mouse_controller = MouseController()

--- a/src/main.py
+++ b/src/main.py
@@ -55,7 +55,7 @@ def main():
     root.geometry("1280x720")
 
     try:
-        icon_path_ico = resource_path('logo_guara.ico')
+        icon_path_ico = resource_path('assets/logo_guara.ico')
         root.iconbitmap(icon_path_ico)
     except (tk.TclError, FileNotFoundError):
         icon_path_ico = None

--- a/src/ui/preparation_mode.py
+++ b/src/ui/preparation_mode.py
@@ -18,7 +18,7 @@ class PreparationOverlayManager:
         self.indicator = indicator
         self.indicator_text = indicator_text
         self.inactive_text = inactive_text
-        self.logo_path = logo_path if logo_path is not None else resource_path("logo_guara.png")
+        self.logo_path = logo_path if logo_path is not None else resource_path("assets/logo_guara.png")
 
         self.sct = mss.mss()
         self.overlays = {}

--- a/src/utils.py
+++ b/src/utils.py
@@ -4,16 +4,16 @@ import os
 import logging
 from screeninfo import get_monitors
 
-def resource_path(relative_path):
-    """ Obtém o caminho absoluto para um recurso, funciona para dev e para o PyInstaller """
+def resource_path(relative_path: str) -> str:
+    """ Obtém o caminho absoluto para um recurso, funcionando para dev e para o PyInstaller. """
     try:
-        # PyInstaller cria uma pasta temporária e armazena o caminho em _MEIPASS
+        # O PyInstaller cria uma pasta temporária e armazena o caminho em _MEIPASS
         base_path = sys._MEIPASS
     except Exception:
-        # Se não estiver no modo PyInstaller, use o caminho do arquivo
-        base_path = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+        # _MEIPASS não definido, então estamos em modo de desenvolvimento
+        base_path = os.path.abspath(".")
 
-    return os.path.join(base_path, "assets", relative_path)
+    return os.path.join(base_path, relative_path)
 
 def get_primary_monitor_resolution():
     """Retorna a resolução (largura, altura) do monitor primário."""


### PR DESCRIPTION
Implementei a função `resource_path` para obter o caminho absoluto dos recursos (assets), garantindo que funcione tanto em ambiente de desenvolvimento quanto no executável compilado com PyInstaller.

A função anterior adicionava o prefixo 'assets/' automaticamente, o que causava um caminho incorreto quando o PyInstaller descompactava os arquivos. A nova implementação espera o caminho relativo completo (ex: 'assets/logo.png').

Todas as chamadas à função `resource_path` no seu código foram atualizadas para refletir essa mudança, garantindo que os ícones e imagens sejam carregados corretamente em todos os cenários.