### PR TITLE
Fix: Resolve icon and resource loading for PyInstaller build

### DIFF
--- a/Sentinela-main.spec
+++ b/Sentinela-main.spec
@@ -32,7 +32,7 @@ exe = EXE(
     target_arch=None,
     codesign_identity=None,
     entitlements_file=None,
-    icon=['assets\\logo_guara.ico'],
+    icon=['assets\\sentinela.ico'],
 )
 coll = COLLECT(
     exe,

--- a/src/app/main_window.py
+++ b/src/app/main_window.py
@@ -33,6 +33,8 @@ class Bubble:
 class MainApplication(tk.Frame):
     def __init__(self, parent, capture_module, recording_module, app_config):
         super().__init__(parent)
+        # Sela o ícone na janela principal, garantindo sua presença na barra de tarefas
+        self.parent.iconbitmap(resource_path('assets/sentinela.ico'))
         self.parent = parent
         self.capture_module = capture_module
         self.recording_module = recording_module
@@ -62,8 +64,9 @@ class MainApplication(tk.Frame):
             logo_image.thumbnail((200, 60))
             self.logo_tk = ImageTk.PhotoImage(logo_image)
             tk.Label(header_container, image=self.logo_tk, bg=theme["card_bg"]).pack(pady=(0,10))
-        except FileNotFoundError:
-            pass
+        except Exception as e:
+            # Se qualquer erro ocorrer, ele não quebrará o app, mas nos dirá o que aconteceu
+            print(f"ALERTA DA FORJA: Não foi possível carregar o logo. Causa: {e}")
         tk.Label(header_container, text="Sentinela Guará", font=("Segoe UI", 26, "bold"), bg=theme["card_bg"], fg=theme["text_primary"]).pack()
         tk.Label(header_container, text="Gravador de evidências simples e seguro", font=("Segoe UI", 10), bg=theme["card_bg"], fg=theme["text_secondary"]).pack(pady=(0,10))
         tk.Frame(self.main_card_frame, height=1, bg=theme["separator"]).pack(fill="x", padx=40, pady=(15,10))

--- a/src/main.py
+++ b/src/main.py
@@ -55,7 +55,7 @@ def main():
     root.geometry("1280x720")
 
     try:
-        icon_path_ico = resource_path('assets/logo_guara.ico')
+        icon_path_ico = resource_path('assets/sentinela.ico')
         root.iconbitmap(icon_path_ico)
     except (tk.TclError, FileNotFoundError):
         icon_path_ico = None


### PR DESCRIPTION
This commit provides a comprehensive solution to two critical issues affecting the compiled executable: the application icon and the loading of image resources on the main screen.

The root cause of the application icon not displaying correctly on the `.exe` file was identified in the `Sentinela-main.spec` file. The `icon` parameter was pointing to a non-existent file (`logo_guara.ico`). This has been corrected to point to the correct `sentinela.ico` file.

To ensure robustness, the icon is now set in three places:
1.  In `Sentinela-main.spec` for the executable file properties.
2.  In `src/main.py` on the root Tkinter window at startup.
3.  In `src/app/main_window.py` on the parent window, providing a redundant seal.

Additionally, the error handling for the logo image loading on the main screen has been fortified. The `try...except` block now catches any `Exception`, preventing potential crashes and providing a clear error message if the resource fails to load, without interrupting your experience. The existing `resource_path` function call ensures that the path is correctly resolved in both development and bundled modes.