### PR TITLE
O ícone da bandeja do sistema não estava sendo exibido na versão comp…

### DIFF
--- a/src/app/tray_icon.py
+++ b/src/app/tray_icon.py
@@ -26,7 +26,7 @@ def setup_tray_icon(root, capture_module, recording_module, app_config):
             print(f"Não foi possível abrir a pasta de evidências: {e}")
 
     try:
-        image = Image.open(resource_path("assets/logo_guara.ico"))
+        image = Image.open(resource_path("assets/sentinela.ico"))
     except FileNotFoundError:
         # Create a placeholder image with the primary theme color
         image = Image.new('RGB', (64, 64), color = theme["primary"])


### PR DESCRIPTION
…ilada do aplicativo (.exe) porque o caminho para o arquivo de ícone estava incorreto.

A função `setup_tray_icon` tentava carregar `assets/logo_guara.ico`, que não existe. Esta alteração corrige o caminho para usar `assets/sentinela.ico`, que é o mesmo ícone usado pela janela principal do aplicativo.

Isso garante que o ícone da bandeja do sistema seja exibido corretamente, mantendo a consistência visual com o restante da aplicação.